### PR TITLE
feat: Deploy Flask and Express Services to Kubernetes

### DIFF
--- a/k8s-manifests/configmap.yaml
+++ b/k8s-manifests/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flask-config
+data:
+  USER_NAME: "Kubernetes User"

--- a/k8s-manifests/express-deployment.yaml
+++ b/k8s-manifests/express-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: express-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: express-service
+  template:
+    metadata:
+      labels:
+        app: express-service
+    spec:
+      containers:
+      - name: express-service
+        image: express-service:latest
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 3000
+        env:
+        - name: FLASK_SERVICE_HOST
+          value: "flask-service"
+        - name: FLASK_SERVICE_PORT
+          value: "5000"
+        resources: 
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "250m"

--- a/k8s-manifests/express-service.yaml
+++ b/k8s-manifests/express-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: express-service
+spec:
+  selector:
+    app: express-service
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: NodePort

--- a/k8s-manifests/flask-deployment.yaml
+++ b/k8s-manifests/flask-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flask-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flask-service
+  template:
+    metadata:
+      labels:
+        app: flask-service
+    spec:
+      containers:
+      - name: flask-service
+        image: flask-service:latest
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 5000
+        env:
+        - name: USER_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: flask-config
+              key: USER_NAME
+        resources: 
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "250m"

--- a/k8s-manifests/flask-service.yaml
+++ b/k8s-manifests/flask-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flask-service
+spec:
+  selector:
+    app: flask-service
+  ports:
+    - protocol: TCP
+      port: 5000
+      targetPort: 5000


### PR DESCRIPTION
**Description:**
This pull request introduces the necessary Kubernetes manifests to deploy and manage both the Flask backend service and the Express.js gateway service within a Kubernetes cluster. It includes `Deployment` and `Service` definitions for each application, along with a `ConfigMap` to manage shared configuration.

This setup enables the services to run as containerized applications, leveraging Kubernetes for orchestration, scaling, and inter-service communication.

**Key Changes & Components:**

* **`flask-service-deployment.yaml`**:
    * Defines the Kubernetes Deployment for the Flask application.
    * Specifies a single replica, linking to the `flask-service:latest` image.
    * Includes resource requests and limits (`64Mi` memory, `100m` CPU for requests; `128Mi` memory, `250m` CPU for limits) to ensure efficient resource allocation and prevent resource contention.
    * Configures the `USER_NAME` environment variable via a `ConfigMapKeyRef`, linking to `flask-config`.

* **`flask-service-service.yaml`**:
    * Defines the Kubernetes Service for the Flask application.
    * Exposes the Flask service on port `5000` within the cluster, allowing other services (like Express) to discover and communicate with it using the service name `flask-service`.

* **`express-service-deployment.yaml`**:
    * Defines the Kubernetes Deployment for the Express.js gateway application.
    * Specifies a single replica, linking to the `express-service:latest` image.
    * Includes resource requests and limits (`64Mi` memory, `100m` CPU for requests; `128Mi` memory, `250m` CPU for limits).
    * Sets environment variables `FLASK_SERVICE_HOST` to `flask-service` and `FLASK_SERVICE_PORT` to `5000`, enabling the Express service to locate and communicate with the Flask service by its Kubernetes service name.

* **`express-service-service.yaml`**:
    * Defines the Kubernetes Service for the Express.js application.
    * Exposes the Express service on port `3000` within the cluster, making it accessible to other services or potentially via an Ingress (future work).

* **`flask-configmap.yaml`**: (Assuming you have a file named similar to this)
    * Defines a Kubernetes `ConfigMap` named `flask-config`.